### PR TITLE
Update README to reflect current application state

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ A web application for tracking office foosball games, built with Flask and htmx.
 
 ## Features
 
-- ✅ **Player Management**: Add and manage players
+- ✅ **Player Management**: Add and manage players with detailed profiles
 - ✅ **Game Recording**: Record games with scores, players, and timestamps
 - ✅ **Multiple Game Types**: Support for 1v1, 2v2, and 2v1 matches
-- ✅ **Leaderboard**: Comprehensive rankings with win rates and statistics
+- ✅ **ELO Rating System**: Dynamic player rankings using ELO algorithm with historical tracking
+- ✅ **Leaderboard**: Comprehensive rankings with ELO ratings, win rates, and statistics
+- ✅ **Historical Tracking**: Daily leaderboard snapshots to track player progression over time
+- ✅ **Tournament System**: Create and manage single-elimination tournaments with bracket visualization
 - ✅ **Cake Counter**: Track cake debts from 10-0 shutouts
 - ✅ **Statistics Dashboard**: Interactive charts and detailed analytics
+- ✅ **Badges & Achievements**: Award players with badges based on performance
+- ✅ **Streak Tracking**: Monitor current and best winning streaks
+- ✅ **Player Profiles**: Detailed player pages with game history and personal statistics
 - ✅ **Game Duration Tracking**: Optional start/end time recording
 - ✅ **Responsive Design**: Bootstrap-based UI that works on all devices
 
@@ -66,8 +72,10 @@ The database will persist in the `instance/` directory, so your data is preserve
 
 ### Viewing Statistics
 - **Home**: Quick stats and recent games
-- **Leaderboard**: Player rankings and cake standings
+- **Leaderboard**: Player rankings with ELO ratings and cake standings
 - **Statistics**: Interactive charts and detailed analytics
+- **Player Profiles**: Click any player to see detailed stats, game history, and badges
+- **Tournaments**: Create and manage tournament brackets
 
 ## The Cake Rule 🎂
 
@@ -75,21 +83,59 @@ When a player wins 10-0 (a shutout), the losing player(s) owe the winner(s) a ca
 
 ## Database Schema
 
-- **Players**: Store player information
-- **Games**: Store game details (scores, date, duration, type)
-- **GamePlayers**: Link players to games with team assignments
-- **CakeBalances**: Track cake debts between players
+The application uses SQLite with the following models:
 
-## Development
+- **Player**: Player information including name, ELO rating (default 1500), and creation timestamp
+- **Game**: Game records with scores for both teams, game type (1v1, 2v2, 2v1), start time, optional end time, and computed properties for duration and shutout detection
+- **GamePlayer**: Junction table linking players to games with team assignment (1 or 2), winner status, and ELO change for that specific game
+- **CakeBalance**: Tracks cake debts between players from 10-0 shutouts
+- **LeaderboardHistory**: Daily snapshots of leaderboard positions including rank, ELO rating, and total games played for historical tracking
+- **Tournament**: Tournament records with name, status (setup/active/completed), and timestamps
+- **TournamentParticipant**: Links players to tournaments with seeding information
+- **TournamentMatch**: Tournament bracket matches with players, winners, game links, and bracket structure
 
-The application uses htmx for dynamic updates without page refreshes. All API endpoints return HTML fragments that are swapped into the page, providing a smooth user experience.
+### Key Features:
+- **ELO Rating System**: Each player has a rating that changes based on game outcomes
+- **Historical Tracking**: Daily leaderboard snapshots allow tracking player progression over time
+- **Per-Game ELO Changes**: The `elo_change` field in GamePlayer records the rating change for each player in each game
+- **Tournament Brackets**: Single-elimination tournaments with proper seeding and match progression
 
-To extend the application, you can:
+## Architecture
+
+The application uses a modular Flask blueprint architecture with hypermedia-driven design:
+
+### Application Structure:
+- **services/**: Business logic layer with dedicated services for ELO calculations, game management, statistics, tournaments, and leaderboard tracking
+- **blueprints/**: Flask blueprints organized by feature (pages, players, games, leaderboard, statistics, tournaments)
+- **templates/**: Full page templates and HTML fragments for htmx responses
+- **models.py**: SQLAlchemy database models (8 models)
+
+### htmx Integration:
+All API endpoints (prefixed with `/api/`) return HTML fragments instead of JSON. htmx makes AJAX requests and swaps responses directly into the DOM, providing dynamic updates without full page refreshes or complex JavaScript.
+
+### Database Migrations:
+The project uses Flask-Migrate for schema management. After model changes:
+```bash
+flask db migrate -m "Description of changes"
+flask db upgrade
+```
+
+After migrations affecting ratings or game history, recalculate ELO ratings:
+```bash
+python recalculate_elo.py
+```
+
+This script recalculates all ELO ratings from scratch and regenerates historical leaderboard snapshots.
+
+## Extending the Application
+
+Potential enhancements:
 - Add new statistics and charts
-- Implement player profiles
-- Add tournament functionality
-- Create mobile-specific features
-- Add export functionality for data analysis
+- Implement data export functionality (CSV, JSON)
+- Add player vs player head-to-head statistics
+- Create tournament scheduling and notifications
+- Add mobile-specific optimizations
+- Implement team-based tournaments
 
 Enjoy tracking your foosball games! ⚽
 


### PR DESCRIPTION
The README was significantly outdated. Updated to include:
- ELO rating system with historical tracking
- Tournament functionality with bracket visualization
- Historical leaderboard snapshots
- Badges and achievements system
- Player profile pages
- Complete database schema (all 8 models)
- Modular Flask blueprint architecture details
- Database migration instructions

Removed suggestions for features that already exist and added more accurate technical documentation.