### PR TITLE
Add played game badge

### DIFF
--- a/services/statistics_service.py
+++ b/services/statistics_service.py
@@ -232,11 +232,11 @@ def calculate_badges(player_stats, all_players_stats, cached_data=None):
         current_streak, best_streak = calculate_player_streaks(player.id)
 
     if current_streak >= 10:
-        badges.append({"emoji": "💥", "label": "Unstoppable", "color": "danger", "tooltip": f"Unstoppable: Currently on a {current_streak} game winning streak!"})
+        badges.append({"emoji": "💥", "label": "Unstoppable", "color": "danger", "tooltip": f"Currently on a {current_streak} game winning streak!"})
     elif current_streak >= 5:
-        badges.append({"emoji": "🔥", "label": "On Fire", "color": "danger", "tooltip": f"On Fire: Currently on a {current_streak} game winning streak!"})
+        badges.append({"emoji": "🔥", "label": "On Fire", "color": "danger", "tooltip": f"Currently on a {current_streak} game winning streak!"})
     elif current_streak >= 3:
-        badges.append({"emoji": "⚡", "label": "Hot Streak", "color": "warning", "tooltip": f"Hot Streak: Currently on a {current_streak} game winning streak!"})
+        badges.append({"emoji": "⚡", "label": "Hot Streak", "color": "warning", "tooltip": f"Currently on a {current_streak} game winning streak!"})
 
     # Performance Badges
     if player_stats["total_games"] >= 10 and player_stats["win_rate"] == 100:

--- a/templates/partials/leaderboard.html
+++ b/templates/partials/leaderboard.html
@@ -35,7 +35,7 @@
                         <span class="achievement-badge-icon"
                               data-bs-toggle="tooltip"
                               data-bs-placement="top"
-                              title="{{ badge.tooltip }}">{{ badge.emoji }}</span>
+                              title="{{ badge.label }}: {{ badge.tooltip }}">{{ badge.emoji }}</span>
                         {% endfor %}
                     </div>
                 </td>

--- a/templates/partials/leaderboard.html
+++ b/templates/partials/leaderboard.html
@@ -35,7 +35,7 @@
                         <span class="achievement-badge-icon"
                               data-bs-toggle="tooltip"
                               data-bs-placement="top"
-                              title="{{ badge.label }}: {{ badge.tooltip }}">{{ badge.emoji }}</span>
+                              title="{{ badge.tooltip }}">{{ badge.emoji }}</span>
                         {% endfor %}
                     </div>
                 </td>


### PR DESCRIPTION
- Add Night owl badge (🦉): Played a game between 8pm and 6am
- Add Early bird badge (🐦): Played a game between 6am and 9am
- Add Cat badge (🐱): Lost against majority of unique opponents
- Add Addict badge (💉): Played 21+ games in any 7-day period (3+ per day average)
- Fix tooltip bug where badge label was duplicated (e.g., "On fire: On fire")

All new badges are computed efficiently in bulk using the precompute_badge_data function to minimize database queries.