### PR TITLE
Add quarterly season system with historical ELO tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask_migrate import Migrate
 from config import Config
 from models import db
 from services.elo_service import recalculate_all_elo_ratings
+from services.season_service import get_current_season
 
 
 def create_app():
@@ -36,6 +37,8 @@ if __name__ == "__main__":
     app = create_app()
     with app.app_context():
         db.create_all()
-        # Recalculate ELO ratings on startup
-        recalculate_all_elo_ratings()
+        # Ensure current season exists (auto-transitions if needed)
+        current_season = get_current_season()
+        # Recalculate ELO ratings for current season on startup
+        recalculate_all_elo_ratings(season_id=current_season.id)
     app.run(debug=True, host="0.0.0.0")

--- a/migrations/versions/b1c2d3e4f5g6_add_season_system.py
+++ b/migrations/versions/b1c2d3e4f5g6_add_season_system.py
@@ -1,0 +1,269 @@
+"""Add season system
+
+Revision ID: b1c2d3e4f5g6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-02-13 16:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b1c2d3e4f5g6'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Step 1: Create season table
+    op.create_table('season',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=50), nullable=False),
+        sa.Column('start_date', sa.DateTime(), nullable=False),
+        sa.Column('end_date', sa.DateTime(), nullable=False),
+        sa.Column('is_current', sa.Boolean(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name')
+    )
+
+    # Create index on is_current for fast current season lookup
+    op.create_index('ix_season_is_current', 'season', ['is_current'], unique=False)
+
+    # Step 2: Add season_id columns (nullable initially)
+    with op.batch_alter_table('game', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('season_id', sa.Integer(), nullable=True))
+
+    with op.batch_alter_table('cake_balance', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('season_id', sa.Integer(), nullable=True))
+
+    with op.batch_alter_table('leaderboard_history', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('season_id', sa.Integer(), nullable=True))
+
+    # Step 3: Create seasons based on actual game dates
+    # Get connection to execute queries
+    conn = op.get_bind()
+
+    # Get min and max game dates
+    result = conn.execute(sa.text("SELECT MIN(start_time), MAX(start_time) FROM game"))
+    min_date, max_date = result.fetchone()
+
+    if min_date and max_date:
+        # Parse dates (handle both with and without microseconds)
+        from datetime import datetime
+        try:
+            min_dt = datetime.strptime(min_date, '%Y-%m-%d %H:%M:%S.%f')
+        except ValueError:
+            min_dt = datetime.strptime(min_date, '%Y-%m-%d %H:%M:%S')
+
+        try:
+            max_dt = datetime.strptime(max_date, '%Y-%m-%d %H:%M:%S.%f')
+        except ValueError:
+            max_dt = datetime.strptime(max_date, '%Y-%m-%d %H:%M:%S')
+
+        # Helper function to get quarter info
+        def get_quarter(dt):
+            month = dt.month
+            year = dt.year
+            quarter = (month - 1) // 3 + 1
+            return year, quarter
+
+        # Helper function to get quarter boundaries
+        def get_quarter_boundaries(year, quarter):
+            start_month = (quarter - 1) * 3 + 1
+            if quarter == 4:
+                end_month = 12
+                end_day = 31
+            else:
+                end_month = start_month + 2
+                if end_month == 3:
+                    # February
+                    if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0):
+                        end_day = 29
+                    else:
+                        end_day = 28
+                elif end_month in [1, 3, 5, 7, 8, 10, 12]:
+                    end_day = 31
+                else:
+                    end_day = 30
+
+            start_date = f"{year}-{start_month:02d}-01 00:00:00"
+            end_date = f"{year}-{end_month:02d}-{end_day} 23:59:59"
+            return start_date, end_date
+
+        # Create all necessary seasons
+        start_year, start_quarter = get_quarter(min_dt)
+        end_year, end_quarter = get_quarter(max_dt)
+
+        current_year = start_year
+        current_quarter = start_quarter
+
+        # Determine which season should be current (the one containing max_date)
+        current_season_name = f"Q{end_quarter} {end_year}"
+
+        while (current_year < end_year) or (current_year == end_year and current_quarter <= end_quarter):
+            season_name = f"Q{current_quarter} {current_year}"
+            start_date, end_date = get_quarter_boundaries(current_year, current_quarter)
+            is_current = 1 if season_name == current_season_name else 0
+
+            op.execute(
+                sa.text(
+                    """
+                    INSERT INTO season (name, start_date, end_date, is_current, created_at)
+                    VALUES (:name, :start_date, :end_date, :is_current, datetime('now'))
+                    """
+                ).bindparams(
+                    name=season_name,
+                    start_date=start_date,
+                    end_date=end_date,
+                    is_current=is_current
+                )
+            )
+
+            # Move to next quarter
+            current_quarter += 1
+            if current_quarter > 4:
+                current_quarter = 1
+                current_year += 1
+    else:
+        # No games exist, create current quarter as default
+        from datetime import datetime
+        now = datetime.utcnow()
+        year = now.year
+        quarter = (now.month - 1) // 3 + 1
+
+        def get_quarter_boundaries(year, quarter):
+            start_month = (quarter - 1) * 3 + 1
+            if quarter == 4:
+                end_month = 12
+                end_day = 31
+            else:
+                end_month = start_month + 2
+                if end_month in [1, 3, 5, 7, 8, 10, 12]:
+                    end_day = 31
+                else:
+                    end_day = 30
+
+            start_date = f"{year}-{start_month:02d}-01 00:00:00"
+            end_date = f"{year}-{end_month:02d}-{end_day} 23:59:59"
+            return start_date, end_date
+
+        season_name = f"Q{quarter} {year}"
+        start_date, end_date = get_quarter_boundaries(year, quarter)
+
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO season (name, start_date, end_date, is_current, created_at)
+                VALUES (:name, :start_date, :end_date, 1, datetime('now'))
+                """
+            ).bindparams(
+                name=season_name,
+                start_date=start_date,
+                end_date=end_date
+            )
+        )
+
+    # Step 4: Assign games to correct seasons based on their start_time
+    # For each season, update games that fall within its date range
+    seasons = conn.execute(sa.text("SELECT id, start_date, end_date FROM season"))
+    for season_id, start_date, end_date in seasons:
+        op.execute(
+            sa.text(
+                """
+                UPDATE game
+                SET season_id = :season_id
+                WHERE start_time >= :start_date AND start_time <= :end_date
+                """
+            ).bindparams(
+                season_id=season_id,
+                start_date=start_date,
+                end_date=end_date
+            )
+        )
+
+    # Assign leaderboard_history to seasons based on snapshot_date
+    seasons = conn.execute(sa.text("SELECT id, start_date, end_date FROM season"))
+    for season_id, start_date, end_date in seasons:
+        op.execute(
+            sa.text(
+                """
+                UPDATE leaderboard_history
+                SET season_id = :season_id
+                WHERE snapshot_date >= date(:start_date) AND snapshot_date <= date(:end_date)
+                """
+            ).bindparams(
+                season_id=season_id,
+                start_date=start_date,
+                end_date=end_date
+            )
+        )
+
+    # For cake_balance, assign to the most recent season (since they don't have dates)
+    # This will be recalculated properly when games are processed
+    current_season = conn.execute(sa.text("SELECT id FROM season WHERE is_current = 1")).fetchone()
+    if current_season:
+        op.execute(
+            sa.text("UPDATE cake_balance SET season_id = :season_id").bindparams(
+                season_id=current_season[0]
+            )
+        )
+
+    # Step 5: Make season_id non-nullable and add foreign keys
+    with op.batch_alter_table('game', schema=None) as batch_op:
+        batch_op.alter_column('season_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.create_foreign_key('fk_game_season_id', 'season', ['season_id'], ['id'])
+        batch_op.create_index('ix_game_season_id', ['season_id'], unique=False)
+
+    with op.batch_alter_table('cake_balance', schema=None) as batch_op:
+        batch_op.alter_column('season_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.create_foreign_key('fk_cake_balance_season_id', 'season', ['season_id'], ['id'])
+        batch_op.create_index('ix_cake_balance_season_id', ['season_id'], unique=False)
+
+    # Step 6: Update leaderboard_history unique constraint and add foreign key
+    # Check if unique_player_date constraint exists
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    constraints = {c['name'] for c in inspector.get_unique_constraints('leaderboard_history')}
+
+    with op.batch_alter_table('leaderboard_history', schema=None) as batch_op:
+        # Drop old unique constraint only if it exists
+        if 'unique_player_date' in constraints:
+            batch_op.drop_constraint('unique_player_date', type_='unique')
+
+        # Make season_id non-nullable
+        batch_op.alter_column('season_id', existing_type=sa.Integer(), nullable=False)
+        # Add foreign key
+        batch_op.create_foreign_key('fk_leaderboard_history_season_id', 'season', ['season_id'], ['id'])
+        # Create new unique constraint including season_id
+        batch_op.create_unique_constraint('unique_player_season_date', ['player_id', 'season_id', 'snapshot_date'])
+        # Create index
+        batch_op.create_index('ix_leaderboard_history_season_id', ['season_id'], unique=False)
+
+
+def downgrade():
+    # Remove indexes and foreign keys from leaderboard_history
+    with op.batch_alter_table('leaderboard_history', schema=None) as batch_op:
+        batch_op.drop_index('ix_leaderboard_history_season_id')
+        batch_op.drop_constraint('unique_player_season_date', type_='unique')
+        batch_op.drop_constraint('fk_leaderboard_history_season_id', type_='foreignkey')
+        batch_op.create_unique_constraint('unique_player_date', ['player_id', 'snapshot_date'])
+        batch_op.drop_column('season_id')
+
+    # Remove indexes and foreign keys from cake_balance
+    with op.batch_alter_table('cake_balance', schema=None) as batch_op:
+        batch_op.drop_index('ix_cake_balance_season_id')
+        batch_op.drop_constraint('fk_cake_balance_season_id', type_='foreignkey')
+        batch_op.drop_column('season_id')
+
+    # Remove indexes and foreign keys from game
+    with op.batch_alter_table('game', schema=None) as batch_op:
+        batch_op.drop_index('ix_game_season_id')
+        batch_op.drop_constraint('fk_game_season_id', type_='foreignkey')
+        batch_op.drop_column('season_id')
+
+    # Drop season table
+    op.drop_index('ix_season_is_current', table_name='season')
+    op.drop_table('season')

--- a/services/elo_service.py
+++ b/services/elo_service.py
@@ -72,9 +72,15 @@ def update_elo_ratings(game):
         team2_game_players[i].elo_change = team2_change
 
 
-def recalculate_all_elo_ratings():
+def recalculate_all_elo_ratings(season_id=None):
     """
-    Recalculate ELO ratings for all players from scratch by replaying all games.
+    Recalculate ELO ratings for all players from scratch by replaying games.
+
+    Args:
+        season_id: Optional season ID to filter games. If provided, only games
+                   in that season are processed. If None, all games are processed
+                   for all-time view.
+
     This is useful for initializing ELO ratings or fixing inconsistencies.
     """
     # Reset all player ratings to 1500
@@ -82,8 +88,12 @@ def recalculate_all_elo_ratings():
     for player in players:
         player.elo_rating = 1500
 
-    # Get all games in chronological order
-    games = Game.query.order_by(Game.start_time).all()
+    # Get games in chronological order, optionally filtered by season
+    query = Game.query.order_by(Game.start_time)
+    if season_id is not None:
+        query = query.filter_by(season_id=season_id)
+
+    games = query.all()
 
     # Replay each game to update ELO ratings
     for game in games:

--- a/services/game_service.py
+++ b/services/game_service.py
@@ -7,7 +7,7 @@ from models import db, CakeBalance, GameAuditLog
 def update_cake_balance(game):
     """
     Update cake balance for shutout games (10-0).
-    Each loser owes each winner a cake.
+    Each loser owes each winner a cake within the same season.
 
     Args:
         game: Game object with shutout result
@@ -21,18 +21,23 @@ def update_cake_balance(game):
         else:
             losers.append(gp.player_id)
 
-    # Each loser owes each winner a cake
+    # Each loser owes each winner a cake (within the same season)
     for loser_id in losers:
         for winner_id in winners:
             balance = CakeBalance.query.filter_by(
-                debtor_id=loser_id, creditor_id=winner_id
+                season_id=game.season_id,
+                debtor_id=loser_id,
+                creditor_id=winner_id
             ).first()
 
             if balance:
                 balance.balance += 1
             else:
                 balance = CakeBalance(
-                    debtor_id=loser_id, creditor_id=winner_id, balance=1
+                    season_id=game.season_id,
+                    debtor_id=loser_id,
+                    creditor_id=winner_id,
+                    balance=1
                 )
                 db.session.add(balance)
 

--- a/services/recalculation_service.py
+++ b/services/recalculation_service.py
@@ -6,25 +6,46 @@ from services.leaderboard_service import recalculate_historical_snapshots
 from services.game_service import update_cake_balance
 
 
-def recalculate_all_derived_data():
+def recalculate_all_derived_data(season_id=None):
     """
     Recalculate all derived data (ELO, cake balances, leaderboard history).
     Must be called after editing any game to maintain data integrity.
+
+    Args:
+        season_id: Optional season ID to recalculate. If provided, only recalculates
+                   data for that season. If None, recalculates all seasons.
     """
-    # 1. Clear all ELO changes
-    GamePlayer.query.update({GamePlayer.elo_change: None})
+    # 1. Clear ELO changes (for all games or specific season)
+    if season_id is not None:
+        # Clear ELO changes for games in this season
+        db.session.query(GamePlayer).filter(
+            GamePlayer.game_id.in_(
+                db.session.query(Game.id).filter_by(season_id=season_id)
+            )
+        ).update({GamePlayer.elo_change: None}, synchronize_session=False)
+    else:
+        GamePlayer.query.update({GamePlayer.elo_change: None})
 
     # 2. Recalculate ELO ratings from scratch
-    recalculate_all_elo_ratings()
+    recalculate_all_elo_ratings(season_id=season_id)
 
     # 3. Rebuild cake balances
-    CakeBalance.query.delete()
-    games = Game.query.order_by(Game.start_time).all()
+    if season_id is not None:
+        # Delete only cake balances for this season
+        CakeBalance.query.filter_by(season_id=season_id).delete()
+        # Rebuild cake balances for this season
+        games = Game.query.filter_by(season_id=season_id).order_by(Game.start_time).all()
+    else:
+        # Delete all cake balances
+        CakeBalance.query.delete()
+        # Rebuild all cake balances
+        games = Game.query.order_by(Game.start_time).all()
+
     for game in games:
         if game.is_shutout:
             update_cake_balance(game)
 
     # 4. Recalculate historical snapshots
-    recalculate_historical_snapshots()
+    recalculate_historical_snapshots(season_id=season_id)
 
     db.session.commit()

--- a/services/season_service.py
+++ b/services/season_service.py
@@ -1,0 +1,162 @@
+from datetime import datetime, timedelta
+from models import db, Season, Player
+
+
+def get_quarter_info(date):
+    """
+    Returns (quarter_num, year) for a given date.
+
+    Args:
+        date: datetime object
+
+    Returns:
+        tuple: (quarter_num, year) where quarter_num is 1-4
+    """
+    month = date.month
+    year = date.year
+    quarter = (month - 1) // 3 + 1
+    return quarter, year
+
+
+def get_quarter_boundaries(year, quarter):
+    """
+    Returns (start_date, end_date) for a given year and quarter.
+
+    Args:
+        year: int
+        quarter: int (1-4)
+
+    Returns:
+        tuple: (start_date, end_date) as datetime objects
+    """
+    if quarter not in [1, 2, 3, 4]:
+        raise ValueError("Quarter must be between 1 and 4")
+
+    start_month = (quarter - 1) * 3 + 1
+    if quarter == 4:
+        end_month = 12
+        end_day = 31
+    else:
+        end_month = start_month + 2
+        if end_month == 3:
+            # February - handle leap years
+            if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0):
+                end_day = 29
+            else:
+                end_day = 28
+        elif end_month in [1, 3, 5, 7, 8, 10, 12]:
+            end_day = 31
+        else:
+            end_day = 30
+
+    start_date = datetime(year, start_month, 1, 0, 0, 0)
+    end_date = datetime(year, end_month, end_day, 23, 59, 59)
+
+    return start_date, end_date
+
+
+def create_season(year, quarter):
+    """
+    Creates a new season for the given year and quarter.
+
+    Args:
+        year: int
+        quarter: int (1-4)
+
+    Returns:
+        Season: The newly created season
+    """
+    name = f"Q{quarter} {year}"
+    start_date, end_date = get_quarter_boundaries(year, quarter)
+
+    season = Season(
+        name=name,
+        start_date=start_date,
+        end_date=end_date,
+        is_current=False
+    )
+    db.session.add(season)
+    db.session.commit()
+
+    return season
+
+
+def get_current_season():
+    """
+    Gets or auto-creates the current season based on the current date.
+    If the current date is past the current season's end_date, automatically
+    transitions to the next quarter's season.
+
+    Returns:
+        Season: The current season
+    """
+    now = datetime.utcnow()
+
+    # Try to get the current season
+    current_season = Season.query.filter_by(is_current=True).first()
+
+    # Check if we need to transition to a new season
+    if current_season and now > current_season.end_date:
+        # Time to transition to next quarter
+        current_quarter, current_year = get_quarter_info(current_season.end_date + timedelta(days=1))
+        new_season = create_season(current_year, current_quarter)
+        transition_to_season(new_season)
+        return new_season
+
+    # If no current season exists, create one for the current quarter
+    if not current_season:
+        quarter, year = get_quarter_info(now)
+        season = create_season(year, quarter)
+        transition_to_season(season)
+        return season
+
+    return current_season
+
+
+def transition_to_season(season):
+    """
+    Transitions to a new season by:
+    1. Unmarking all other seasons as current
+    2. Marking the given season as current
+    3. Resetting all player ELO ratings to 1500
+
+    Args:
+        season: Season object to transition to
+    """
+    # Unmark all seasons as current
+    Season.query.update({Season.is_current: False})
+
+    # Mark this season as current
+    season.is_current = True
+
+    # Reset all player ELO ratings to 1500
+    players = Player.query.all()
+    for player in players:
+        player.elo_rating = 1500
+
+    db.session.commit()
+
+
+def get_season_for_date(date):
+    """
+    Returns the season that contains the given date.
+    If no season exists for that date, creates one.
+
+    Args:
+        date: datetime object
+
+    Returns:
+        Season: The season containing this date
+    """
+    # Find existing season that contains this date
+    season = Season.query.filter(
+        Season.start_date <= date,
+        Season.end_date >= date
+    ).first()
+
+    if season:
+        return season
+
+    # No season found, create one for this date's quarter
+    quarter, year = get_quarter_info(date)
+    return create_season(year, quarter)

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -6,18 +6,34 @@
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">🏆 Leaderboard</h5>
-                <div class="form-check form-switch">
-                    <input class="form-check-input" type="checkbox" id="minGamesToggle"
-                           hx-get="/api/leaderboard"
-                           hx-target="#leaderboard-content"
-                           hx-include="this"
-                           hx-vals='js:{"min_games": document.getElementById("minGamesToggle").checked ? 5 : 0}'>
-                    <label class="form-check-label" for="minGamesToggle">
-                        5+ games only
-                    </label>
+                <div class="d-flex gap-3 align-items-center">
+                    <!-- Season Selector -->
+                    <div class="form-group mb-0">
+                        <label for="seasonSelector" class="form-label mb-0 me-2 small">Season:</label>
+                        <select id="seasonSelector" class="form-select form-select-sm d-inline-block" style="width: auto;"
+                                hx-get="/api/leaderboard"
+                                hx-target="#leaderboard-content"
+                                hx-include="#minGamesToggle"
+                                hx-vals='js:{"min_games": document.getElementById("minGamesToggle").checked ? 5 : 0, "season": document.getElementById("seasonSelector").value}'>
+                            <option value="current">Current Season</option>
+                            <option value="all-time">All Time</option>
+                        </select>
+                    </div>
+
+                    <!-- Min Games Toggle -->
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="minGamesToggle"
+                               hx-get="/api/leaderboard"
+                               hx-target="#leaderboard-content"
+                               hx-include="#seasonSelector"
+                               hx-vals='js:{"min_games": document.getElementById("minGamesToggle").checked ? 5 : 0, "season": document.getElementById("seasonSelector").value}'>
+                        <label class="form-check-label" for="minGamesToggle">
+                            5+ games only
+                        </label>
+                    </div>
                 </div>
             </div>
-            <div class="card-body" id="leaderboard-content" hx-get="/api/leaderboard" hx-trigger="load" hx-vals='js:{"min_games": getMinGamesFilter()}'>
+            <div class="card-body" id="leaderboard-content" hx-get="/api/leaderboard" hx-trigger="load" hx-vals='js:{"min_games": (localStorage.getItem("leaderboard_min_games_filter") === "false" ? 0 : 5), "season": (localStorage.getItem("leaderboard_season_filter") || "current")}'>
                 <div class="text-center">
                     <div class="spinner-border" role="status">
                         <span class="visually-hidden">Loading...</span>
@@ -73,14 +89,25 @@
 </div>
 
 <script>
-    // localStorage key for the min games filter setting
+    // localStorage keys
     const MIN_GAMES_STORAGE_KEY = 'leaderboard_min_games_filter';
+    const SEASON_STORAGE_KEY = 'leaderboard_season_filter';
 
     // Function to get the min games filter value from localStorage
     function getMinGamesFilter() {
         const stored = localStorage.getItem(MIN_GAMES_STORAGE_KEY);
         // Default to true (5 games minimum) if not set
         return stored === null ? 5 : (stored === 'true' ? 5 : 0);
+    }
+
+    // Function to get the season filter value from localStorage
+    function getSeasonFilter() {
+        return localStorage.getItem(SEASON_STORAGE_KEY) || 'current';
+    }
+
+    // Function to save season filter to localStorage
+    function saveSeasonFilter(value) {
+        localStorage.setItem(SEASON_STORAGE_KEY, value);
     }
 
     // Initialize the toggle state from localStorage on page load
@@ -95,6 +122,52 @@
             localStorage.setItem(MIN_GAMES_STORAGE_KEY, this.checked);
             loadPositionChart();
         });
+
+        // Load season options from API
+        fetch('/api/season-options')
+            .then(response => response.json())
+            .then(data => {
+                const selector = document.getElementById('seasonSelector');
+                // Clear existing options
+                selector.innerHTML = '';
+
+                // Add current season option
+                const currentOpt = document.createElement('option');
+                currentOpt.value = 'current';
+                const currentSeasonName = data.seasons.find(s => s.is_current)?.name || '';
+                currentOpt.textContent = `Current Season${currentSeasonName ? ' (' + currentSeasonName + ')' : ''}`;
+                selector.appendChild(currentOpt);
+
+                // Add all-time option
+                const allTimeOpt = document.createElement('option');
+                allTimeOpt.value = 'all-time';
+                allTimeOpt.textContent = 'All Time';
+                selector.appendChild(allTimeOpt);
+
+                // Add past seasons if any
+                const pastSeasons = data.seasons.filter(s => !s.is_current);
+                if (pastSeasons.length > 0) {
+                    const optgroup = document.createElement('optgroup');
+                    optgroup.label = 'Past Seasons';
+                    pastSeasons.forEach(season => {
+                        const opt = document.createElement('option');
+                        opt.value = season.id;
+                        opt.textContent = season.name;
+                        optgroup.appendChild(opt);
+                    });
+                    selector.appendChild(optgroup);
+                }
+
+                // Restore saved selection
+                selector.value = getSeasonFilter();
+
+                // Save on change and reload chart
+                selector.addEventListener('change', function() {
+                    saveSeasonFilter(this.value);
+                    loadPositionChart();
+                });
+            })
+            .catch(error => console.error('Error loading season options:', error));
     });
 
     // Initialize tooltips when content is loaded dynamically via htmx
@@ -155,13 +228,14 @@
     // Function to load and render position chart
     function loadPositionChart() {
         const minGames = getMinGamesFilter();
+        const season = getSeasonFilter();
 
         // Destroy existing chart if it exists
         if (positionChartInstance) {
             positionChartInstance.destroy();
         }
 
-        fetch(`/api/leaderboard-position-chart?min_games=${minGames}`)
+        fetch(`/api/leaderboard-position-chart?min_games=${minGames}&season=${season}`)
             .then(response => response.json())
             .then(data => {
                 const ctx = document.getElementById('positionChart').getContext('2d');

--- a/templates/partials/leaderboard.html
+++ b/templates/partials/leaderboard.html
@@ -69,7 +69,7 @@
 </div>
 
 {% set hx_get = url_for('leaderboard.get_leaderboard') %}
-{% set hx_params = {'min_games': min_games} %}
+{% set hx_params = {'min_games': min_games, 'season': season_filter} %}
 {% set hx_target = '#leaderboard-content' %}
 {% include 'partials/pagination.html' %}
 

--- a/templates/partials/season_selector.html
+++ b/templates/partials/season_selector.html
@@ -1,0 +1,17 @@
+<select id="seasonSelector" class="form-select form-select-sm" name="season">
+    <option value="current" {% if selected == 'current' %}selected{% endif %}>
+        Current Season{% if current_season %} ({{ current_season.name }}){% endif %}
+    </option>
+    <option value="all-time" {% if selected == 'all-time' %}selected{% endif %}>
+        All Time
+    </option>
+    {% if past_seasons %}
+    <optgroup label="Past Seasons">
+        {% for season in past_seasons %}
+        <option value="{{ season.id }}" {% if selected == season.id|string %}selected{% endif %}>
+            {{ season.name }}
+        </option>
+        {% endfor %}
+    </optgroup>
+    {% endif %}
+</select>


### PR DESCRIPTION
Implements a seasonal system where:
- Seasons run automatically by calendar quarters (Q1-Q4)
- Games are assigned to seasons based on their start_time
- ELO ratings are calculated per-season (reset to 1500 each quarter)
- All historical data is preserved and queryable
- UI includes season selector for current/past/all-time views

Key changes:
- Add Season model with quarterly boundaries
- Add season_id foreign keys to Game, CakeBalance, LeaderboardHistory
- Create season_service for season management and auto-transitions
- Update ELO calculations to support season-specific and all-time views
- Add season filtering to all leaderboard and statistics endpoints
- Implement season selector UI with localStorage persistence
- Fix htmx timing issues by reading DOM state directly

Migration creates seasons from actual game dates and assigns all
existing games to their respective quarters.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
